### PR TITLE
Enhance usability of ModelZoo-YOLOv7

### DIFF
--- a/auto_process.py
+++ b/auto_process.py
@@ -29,6 +29,7 @@ from models.yolo import Model
 from models.common import *
 from models.experimental import attempt_load, End2End
 from train import train
+from train_aux import train as train_aux
 from yolov7_fx2p import fx2p
 
 
@@ -82,7 +83,10 @@ def train_run(opt):
             prefix = colorstr('tensorboard: ')
             logger.info(f"{prefix}Start with 'tensorboard --logdir {opt.project}', view at http://localhost:6006/")
             tb_writer = SummaryWriter(opt.save_dir)  # Tensorboard
-        train(hyp, opt, device, tb_writer)
+        if opt.name in ['yolov7', 'yolov7x']: # Use different func
+            train(hyp.copy(), opt, device, tb_writer)
+        else:
+            train_aux(hyp.copy(), opt, device, tb_writer)
 
     # Evolve hyperparameters (optional)
     else:
@@ -163,7 +167,10 @@ def train_run(opt):
                 hyp[k] = round(hyp[k], 5)  # significant digits
 
             # Train mutation
-            results = train(hyp.copy(), opt, device)
+            if opt.name in ['yolov7', 'yolov7x']: # Use different func
+                results = train(hyp.copy(), opt, device)
+            else:
+                results = train_aux(hyp.copy(), opt, device)
 
             # Write mutation results
             print_mutation(hyp.copy(), results, yaml_file, opt.bucket)

--- a/auto_process.py
+++ b/auto_process.py
@@ -175,6 +175,113 @@ def train_run(opt):
     
     return opt
 
+def export_onnx(opt, save_path):
+    device = select_device(opt.export_device)
+    model = attempt_load(opt.weights, map_location=device)  # load FP32 model
+    labels = model.names
+
+    # Checks
+    gs = int(max(model.stride))  # grid size (max stride)
+    opt.img_size = [check_img_size(x, gs) for x in opt.img_size]  # verify img_size are gs-multiples
+
+    # Input
+    img = torch.zeros(1, 3, *opt.img_size).to(device)  # image size(1,3,320,192) iDetection
+
+    # Update model
+    for k, m in model.named_modules():
+        m._non_persistent_buffers_set = set()  # pytorch 1.6.0 compatibility
+        if isinstance(m, models.common.Conv):  # assign export-friendly activations
+            if isinstance(m.act, nn.Hardswish):
+                m.act = Hardswish()
+            elif isinstance(m.act, nn.SiLU):
+                m.act = SiLU()
+        # elif isinstance(m, models.yolo.Detect):
+        #     m.forward = m.forward_export  # assign forward (optional)
+    model.model[-1].export = not opt.grid  # set Detect() layer grid export
+    y = model(img)  # dry run
+    if opt.include_nms:
+        model.model[-1].include_nms = True
+        y = None
+
+    model.eval()
+    output_names = ['classes', 'boxes'] if y is None else ['output']
+    dynamic_axes = None
+    if opt.dynamic:
+        dynamic_axes = {'images': {0: 'batch', 2: 'height', 3: 'width'},  # size(1,3,640,640)
+            'output': {0: 'batch', 2: 'y', 3: 'x'}}
+    if opt.dynamic_batch:
+        opt.batch_size = 'batch'
+        dynamic_axes = {
+            'images': {
+                0: 'batch',
+            }, }
+        if opt.end2end and opt.max_wh is None:
+            output_axes = {
+                'num_dets': {0: 'batch'},
+                'det_boxes': {0: 'batch'},
+                'det_scores': {0: 'batch'},
+                'det_classes': {0: 'batch'},
+            }
+        else:
+            output_axes = {
+                'output': {0: 'batch'},
+            }
+        dynamic_axes.update(output_axes)
+    if opt.grid:
+        if opt.end2end:
+            print('\nStarting export end2end onnx model for %s...' % 'TensorRT' if opt.max_wh is None else 'onnxruntime')
+            model = End2End(model,opt.topk_all,opt.iou_thres,opt.conf_thres,opt.max_wh,device,len(labels))
+            if opt.end2end and opt.max_wh is None:
+                output_names = ['num_dets', 'det_boxes', 'det_scores', 'det_classes']
+                shapes = [opt.batch_size, 1, opt.batch_size, opt.topk_all, 4,
+                            opt.batch_size, opt.topk_all, opt.batch_size, opt.topk_all]
+            else:
+                output_names = ['output']
+        else:
+            model.model[-1].concat = True
+
+    torch.onnx.export(model, img, save_path, verbose=False, opset_version=12, input_names=['images'],
+                        output_names=output_names,
+                        dynamic_axes=dynamic_axes)
+
+    # Checks
+    onnx_model = onnx.load(save_path)  # load onnx model
+    onnx.checker.check_model(onnx_model)  # check onnx model
+
+    if opt.end2end and opt.max_wh is None:
+        for i in onnx_model.graph.output:
+            for j in i.type.tensor_type.shape.dim:
+                j.dim_param = str(shapes.pop(0))
+
+    # print(onnx.helper.printable_graph(onnx_model.graph))  # print a human readable model
+
+    # # Metadata
+    # d = {'stride': int(max(model.stride))}
+    # for k, v in d.items():
+    #     meta = onnx_model.metadata_props.add()
+    #     meta.key, meta.value = k, str(v)
+    # onnx.save(onnx_model, f)
+
+    if opt.simplify:
+        try:
+            import onnxsim
+
+            print('\nStarting to simplify ONNX...')
+            onnx_model, check = onnxsim.simplify(onnx_model)
+            assert check, 'assert check failed'
+        except Exception as e:
+            print(f'Simplifier failure: {e}')
+
+    # print(onnx.helper.printable_graph(onnx_model.graph))  # print a human readable model
+    onnx.save(onnx_model, save_path)
+    print('ONNX export success, saved as %s' % save_path)
+
+    if opt.include_nms:
+        print('Registering NMS plugin for ONNX...')
+        mo = RegisterNMS(save_path)
+        mo.register_nms()
+        mo.save(save_path)
+
 def parse_args():
     parser = argparse.ArgumentParser()
 
@@ -231,6 +338,21 @@ def parse_args():
     parser.add_argument('--artifact_alias', type=str, default="latest", help='version of dataset artifact to be used')
     parser.add_argument('--freeze', nargs='+', type=int, default=[0], help='Freeze layers: backbone of yolov7=50, first3=0 1 2')
     parser.add_argument('--v5-metric', action='store_true', help='assume maximum recall as 1.0 in AP calculation')
+
+    """
+        Export arguments
+    """
+    parser.add_argument('--dynamic', action='store_true', help='dynamic ONNX axes')
+    parser.add_argument('--dynamic-batch', action='store_true', help='dynamic batch onnx for tensorrt and onnx-runtime')
+    parser.add_argument('--grid', action='store_true', help='export Detect() layer grid')
+    parser.add_argument('--end2end', action='store_true', help='export end2end onnx')
+    parser.add_argument('--max-wh', type=int, default=None, help='None for tensorrt nms, int value for onnx-runtime nms')
+    parser.add_argument('--topk-all', type=int, default=100, help='topk objects for every images')
+    parser.add_argument('--iou-thres', type=float, default=0.45, help='iou threshold for NMS')
+    parser.add_argument('--conf-thres', type=float, default=0.25, help='conf threshold for NMS')
+    parser.add_argument('--simplify', action='store_true', help='simplify onnx model')
+    parser.add_argument('--include-nms', action='store_true', help='export end2end onnx')
+    parser.add_argument('--export-device', default='cpu', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
 
     return parser.parse_args()
 
@@ -335,3 +457,19 @@ if __name__ == '__main__':
     opt = train_run(opt)
 
     logger.info("Fine-tuning step end.")
+
+    """
+        Export YOLOv5 model to onnx
+    """
+    logger.info("Export model to onnx format step start.")
+    
+    #model = reparam(opt)
+    #torch.save(model, COMPRESSED_MODEL_NAME + '_before_onnx.pt')
+    #opt.weights = COMPRESSED_MODEL_NAME + '_before_onnx.pt'
+
+    opt.weights = opt.save_dir + '/weights/best.pt'
+    export_onnx(opt, COMPRESSED_MODEL_NAME + '.onnx')
+    
+    logger.info(f'=> saving model to {COMPRESSED_MODEL_NAME}.onnx')
+
+    logger.info("Export model to onnx format step end.")

--- a/auto_process.py
+++ b/auto_process.py
@@ -786,7 +786,7 @@ def parse_args():
     """
     parser.add_argument("--compression_method", type=str, choices=["PR_L2", "PR_GM", "PR_NN", "PR_ID", "FD_TK", "FD_CP", "FD_SVD"], default="PR_L2")
     parser.add_argument("--recommendation_method", type=str, choices=["slamp", "vbmf"], default="slamp")
-    parser.add_argument("--compression_ratio", type=int, default=0.5)
+    parser.add_argument("--compression_ratio", type=int, default=0.3)
     parser.add_argument("-m", "--np_email", help="NetsPresso login e-mail", type=str)
     parser.add_argument("-p", "--np_password", help="NetsPresso login password", type=str)
 

--- a/auto_process.py
+++ b/auto_process.py
@@ -1,0 +1,57 @@
+import argparse
+
+import yaml
+from loguru import logger
+import torch
+import torch.fx as fx
+
+from utils.torch_utils import intersect_dicts
+from models.yolo import Model
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    """
+        Common arguments
+    """
+    parser.add_argument('-w', '--weights', type=str, default='./yolov7.pt', help='weights path')
+    parser.add_argument('--data', type=str, default='data/coco.yaml', help='data.yaml path')
+    parser.add_argument('--load_netspresso', action='store_true', help='compress the compressed model')
+
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    opt = parse_args()
+
+    data = opt.data
+    with open(data) as f:
+        data_dict = yaml.load(f, Loader=yaml.SafeLoader)  # data dict
+
+    """ 
+        Convert YOLOv7 model to fx 
+    """
+    logger.info("yolov7 to fx graph start.")
+    
+    load_netspresso = opt.load_netspresso
+    weights = opt.weights
+     
+    if load_netspresso: # after compression, the shape of the yaml file and the model do not match
+        ckpt = torch.load(weights, map_location='cpu')
+        model = ckpt['model'].float()
+    else:
+        nc = int(data_dict['nc'])  # number of classes
+        ckpt = torch.load(weights, map_location='cpu')
+        model = Model(ckpt['model'].yaml, ch=3, nc=nc)
+        state_dict = ckpt['model'].float().state_dict()
+
+        exclude = []
+        state_dict = intersect_dicts(state_dict, model.state_dict(), exclude=exclude)
+        model.load_state_dict(state_dict, strict=False)
+
+    model.train()
+    _graph = fx.Tracer().trace(model, {'augment': False, 'profile':False})
+    traced_model = fx.GraphModule(model, _graph)
+    torch.save(traced_model, "yolov7_fx.pt")
+
+    logger.info("yolov7 to fx graph end.")

--- a/auto_process.py
+++ b/auto_process.py
@@ -1,15 +1,179 @@
 import argparse
+import os
+from pathlib import Path
+import random
+import time
+from copy import deepcopy
 
+import numpy as np
 import yaml
 from loguru import logger
 import torch
 import torch.fx as fx
+from torch.utils.tensorboard import SummaryWriter
+import torch.distributed as dist
+import onnx
 
 from netspresso.compressor import ModelCompressor, Task, Framework
 
 from utils.torch_utils import intersect_dicts
+from utils.general import increment_path, fitness, get_latest_run, check_file, \
+    print_mutation, set_logging, colorstr, check_img_size
+from utils.plots import plot_evolution
+from utils.torch_utils import select_device, intersect_dicts, is_parallel
+from utils.activations import Hardswish, SiLU
+from utils.wandb_logging.wandb_utils import check_wandb_resume
+from utils.add_nms import RegisterNMS
+import models
 from models.yolo import Model
+from models.common import *
+from models.experimental import attempt_load, End2End
+from train import train
+from yolov7_fx2p import fx2p
 
+
+def train_run(opt):
+    # Set DDP variables
+    opt.world_size = int(os.environ['WORLD_SIZE']) if 'WORLD_SIZE' in os.environ else 1
+    opt.global_rank = int(os.environ['RANK']) if 'RANK' in os.environ else -1
+    set_logging(opt.global_rank)
+    #if opt.global_rank in [-1, 0]:
+    #    check_git_status()
+    #    check_requirements()
+
+    # Resume
+    wandb_run = check_wandb_resume(opt)
+    if opt.resume and not wandb_run:  # resume an interrupted run
+        ckpt = opt.resume if isinstance(opt.resume, str) else get_latest_run()  # specified or most recent path
+        assert os.path.isfile(ckpt), 'ERROR: --resume checkpoint does not exist'
+        apriori = opt.global_rank, opt.local_rank
+        with open(Path(ckpt).parent.parent / 'opt.yaml') as f:
+            opt = argparse.Namespace(**yaml.load(f, Loader=yaml.SafeLoader))  # replace
+        opt.cfg, opt.weights, opt.resume, opt.batch_size, opt.global_rank, opt.local_rank = '', ckpt, True, opt.total_batch_size, *apriori  # reinstate
+        logger.info('Resuming training from %s' % ckpt)
+    else:
+        # opt.hyp = opt.hyp or ('hyp.finetune.yaml' if opt.weights else 'hyp.scratch.yaml')
+        opt.data, opt.cfg, opt.hyp = check_file(opt.data), check_file(opt.cfg), check_file(opt.hyp)  # check files
+        assert len(opt.cfg) or len(opt.weights), 'either --cfg or --weights must be specified'
+        opt.img_size.extend([opt.img_size[-1]] * (2 - len(opt.img_size)))  # extend to 2 sizes (train, test)
+        opt.name = 'evolve' if opt.evolve else opt.name
+        opt.save_dir = increment_path(Path(opt.project) / opt.name, exist_ok=opt.exist_ok | opt.evolve)  # increment run
+
+    # DDP mode
+    opt.total_batch_size = opt.batch_size
+    device = select_device(opt.device, batch_size=opt.batch_size)
+    if opt.local_rank != -1:
+        assert torch.cuda.device_count() > opt.local_rank
+        torch.cuda.set_device(opt.local_rank)
+        device = torch.device('cuda', opt.local_rank)
+        dist.init_process_group(backend='nccl', init_method='env://')  # distributed backend
+        assert opt.batch_size % opt.world_size == 0, '--batch-size must be multiple of CUDA device count'
+        opt.batch_size = opt.total_batch_size // opt.world_size
+
+    # Hyperparameters
+    with open(opt.hyp) as f:
+        hyp = yaml.load(f, Loader=yaml.SafeLoader)  # load hyps
+
+    # Train
+    logger.info(opt)
+    if not opt.evolve:
+        tb_writer = None  # init loggers
+        if opt.global_rank in [-1, 0]:
+            prefix = colorstr('tensorboard: ')
+            logger.info(f"{prefix}Start with 'tensorboard --logdir {opt.project}', view at http://localhost:6006/")
+            tb_writer = SummaryWriter(opt.save_dir)  # Tensorboard
+        train(hyp, opt, device, tb_writer)
+
+    # Evolve hyperparameters (optional)
+    else:
+        # Hyperparameter evolution metadata (mutation scale 0-1, lower_limit, upper_limit)
+        meta = {'lr0': (1, 1e-5, 1e-1),  # initial learning rate (SGD=1E-2, Adam=1E-3)
+                'lrf': (1, 0.01, 1.0),  # final OneCycleLR learning rate (lr0 * lrf)
+                'momentum': (0.3, 0.6, 0.98),  # SGD momentum/Adam beta1
+                'weight_decay': (1, 0.0, 0.001),  # optimizer weight decay
+                'warmup_epochs': (1, 0.0, 5.0),  # warmup epochs (fractions ok)
+                'warmup_momentum': (1, 0.0, 0.95),  # warmup initial momentum
+                'warmup_bias_lr': (1, 0.0, 0.2),  # warmup initial bias lr
+                'box': (1, 0.02, 0.2),  # box loss gain
+                'cls': (1, 0.2, 4.0),  # cls loss gain
+                'cls_pw': (1, 0.5, 2.0),  # cls BCELoss positive_weight
+                'obj': (1, 0.2, 4.0),  # obj loss gain (scale with pixels)
+                'obj_pw': (1, 0.5, 2.0),  # obj BCELoss positive_weight
+                'iou_t': (0, 0.1, 0.7),  # IoU training threshold
+                'anchor_t': (1, 2.0, 8.0),  # anchor-multiple threshold
+                'anchors': (2, 2.0, 10.0),  # anchors per output grid (0 to ignore)
+                'fl_gamma': (0, 0.0, 2.0),  # focal loss gamma (efficientDet default gamma=1.5)
+                'hsv_h': (1, 0.0, 0.1),  # image HSV-Hue augmentation (fraction)
+                'hsv_s': (1, 0.0, 0.9),  # image HSV-Saturation augmentation (fraction)
+                'hsv_v': (1, 0.0, 0.9),  # image HSV-Value augmentation (fraction)
+                'degrees': (1, 0.0, 45.0),  # image rotation (+/- deg)
+                'translate': (1, 0.0, 0.9),  # image translation (+/- fraction)
+                'scale': (1, 0.0, 0.9),  # image scale (+/- gain)
+                'shear': (1, 0.0, 10.0),  # image shear (+/- deg)
+                'perspective': (0, 0.0, 0.001),  # image perspective (+/- fraction), range 0-0.001
+                'flipud': (1, 0.0, 1.0),  # image flip up-down (probability)
+                'fliplr': (0, 0.0, 1.0),  # image flip left-right (probability)
+                'mosaic': (1, 0.0, 1.0),  # image mixup (probability)
+                'mixup': (1, 0.0, 1.0),   # image mixup (probability)
+                'copy_paste': (1, 0.0, 1.0),  # segment copy-paste (probability)
+                'paste_in': (1, 0.0, 1.0)}    # segment copy-paste (probability)
+        
+        with open(opt.hyp, errors='ignore') as f:
+            hyp = yaml.safe_load(f)  # load hyps dict
+            if 'anchors' not in hyp:  # anchors commented in hyp.yaml
+                hyp['anchors'] = 3
+                
+        assert opt.local_rank == -1, 'DDP mode not implemented for --evolve'
+        opt.notest, opt.nosave = True, True  # only test/save final epoch
+        # ei = [isinstance(x, (int, float)) for x in hyp.values()]  # evolvable indices
+        yaml_file = Path(opt.save_dir) / 'hyp_evolved.yaml'  # save best result here
+        if opt.bucket:
+            os.system('gsutil cp gs://%s/evolve.txt .' % opt.bucket)  # download evolve.txt if exists
+
+        for _ in range(300):  # generations to evolve
+            if Path('evolve.txt').exists():  # if evolve.txt exists: select best hyps and mutate
+                # Select parent(s)
+                parent = 'single'  # parent selection method: 'single' or 'weighted'
+                x = np.loadtxt('evolve.txt', ndmin=2)
+                n = min(5, len(x))  # number of previous results to consider
+                x = x[np.argsort(-fitness(x))][:n]  # top n mutations
+                w = fitness(x) - fitness(x).min()  # weights
+                if parent == 'single' or len(x) == 1:
+                    # x = x[random.randint(0, n - 1)]  # random selection
+                    x = x[random.choices(range(n), weights=w)[0]]  # weighted selection
+                elif parent == 'weighted':
+                    x = (x * w.reshape(n, 1)).sum(0) / w.sum()  # weighted combination
+
+                # Mutate
+                mp, s = 0.8, 0.2  # mutation probability, sigma
+                npr = np.random
+                npr.seed(int(time.time()))
+                g = np.array([x[0] for x in meta.values()])  # gains 0-1
+                ng = len(meta)
+                v = np.ones(ng)
+                while all(v == 1):  # mutate until a change occurs (prevent duplicates)
+                    v = (g * (npr.random(ng) < mp) * npr.randn(ng) * npr.random() * s + 1).clip(0.3, 3.0)
+                for i, k in enumerate(hyp.keys()):  # plt.hist(v.ravel(), 300)
+                    hyp[k] = float(x[i + 7] * v[i])  # mutate
+
+            # Constrain to limits
+            for k, v in meta.items():
+                hyp[k] = max(hyp[k], v[1])  # lower limit
+                hyp[k] = min(hyp[k], v[2])  # upper limit
+                hyp[k] = round(hyp[k], 5)  # significant digits
+
+            # Train mutation
+            results = train(hyp.copy(), opt, device)
+
+            # Write mutation results
+            print_mutation(hyp.copy(), results, yaml_file, opt.bucket)
+
+        # Plot results
+        plot_evolution(yaml_file)
+        print(f'Hyperparameter evolution complete. Best results saved as: {yaml_file}\n'
+              f'Command to train a new model with these hyperparameters: $ python train.py --hyp {yaml_file}')
+    
+    return opt
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -34,8 +198,39 @@ def parse_args():
     """
         Fine-tuning arguments
     """
+    parser.add_argument('--cfg', type=str, default='', help='model.yaml path')
+    parser.add_argument('--hyp', type=str, default='data/hyp.scratch.p5.yaml', help='hyperparameters path')
+    parser.add_argument('--epochs', type=int, default=300)
+    parser.add_argument('--batch-size', type=int, default=16, help='total batch size for all GPUs')
     parser.add_argument('--img-size', nargs='+', type=int, default=[640, 640], help='[train, test] image sizes')
-
+    parser.add_argument('--rect', action='store_true', help='rectangular training')
+    parser.add_argument('--resume', nargs='?', const=True, default=False, help='resume most recent training')
+    parser.add_argument('--nosave', action='store_true', help='only save final checkpoint')
+    parser.add_argument('--notest', action='store_true', help='only test final epoch')
+    parser.add_argument('--noautoanchor', action='store_true', help='disable autoanchor check')
+    parser.add_argument('--evolve', action='store_true', help='evolve hyperparameters')
+    parser.add_argument('--bucket', type=str, default='', help='gsutil bucket')
+    parser.add_argument('--cache-images', action='store_true', help='cache images for faster training')
+    parser.add_argument('--image-weights', action='store_true', help='use weighted image selection for training')
+    parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
+    parser.add_argument('--multi-scale', action='store_true', help='vary img-size +/- 50%%')
+    parser.add_argument('--single-cls', action='store_true', help='train multi-class data as single-class')
+    parser.add_argument('--adam', action='store_true', help='use torch.optim.Adam() optimizer')
+    parser.add_argument('--sync-bn', action='store_true', help='use SyncBatchNorm, only available in DDP mode')
+    parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
+    parser.add_argument('--workers', type=int, default=8, help='maximum number of dataloader workers')
+    parser.add_argument('--project', default='runs/train', help='save to project/name')
+    parser.add_argument('--entity', default=None, help='W&B entity')
+    parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
+    parser.add_argument('--quad', action='store_true', help='quad dataloader')
+    parser.add_argument('--linear-lr', action='store_true', help='linear LR')
+    parser.add_argument('--label-smoothing', type=float, default=0.0, help='Label smoothing epsilon')
+    parser.add_argument('--upload_dataset', action='store_true', help='Upload dataset as W&B artifact table')
+    parser.add_argument('--bbox_interval', type=int, default=-1, help='Set bounding-box image logging interval for W&B')
+    parser.add_argument('--save_period', type=int, default=-1, help='Log model after every "save_period" epoch')
+    parser.add_argument('--artifact_alias', type=str, default="latest", help='version of dataset artifact to be used')
+    parser.add_argument('--freeze', nargs='+', type=int, default=[0], help='Freeze layers: backbone of yolov7=50, first3=0 1 2')
+    parser.add_argument('--v5-metric', action='store_true', help='assume maximum recall as 1.0 in AP calculation')
 
     return parser.parse_args()
 
@@ -45,6 +240,11 @@ if __name__ == '__main__':
     data = opt.data
     with open(data) as f:
         data_dict = yaml.load(f, Loader=yaml.SafeLoader)  # data dict
+
+    # YOLOv7: 105, YOLOv7x: 121, YOLOv7-W6: 122, YOLOv7-E6:144, YOLOv7-D6: 166, YOLOv7-E6E: 265
+    detect = {'yolov7': 105, 'yolov7x': 121, 'yolov7-w6': 122, 'yolov7-e6': 144, 'yolov7-d6': 166, 'yolov7-e6e': 265}
+    assert opt.name in detect.keys()
+    detect = str(detect[opt.name])
 
     """ 
         Convert YOLOv7 model to fx 
@@ -97,7 +297,7 @@ if __name__ == '__main__':
     COMPRESSION_METHOD = opt.compression_method
     RECOMMENDATION_METHOD = opt.recommendation_method
     RECOMMENDATION_RATIO = opt.compression_ratio
-    COMPRESSED_MODEL_NAME = f'{UPLOAD_MODEL_NAME}_{COMPRESSION_METHOD}_{RECOMMENDATION_RATIO}'
+    COMPRESSED_MODEL_NAME = f'{UPLOAD_MODEL_NAME}_{COMPRESSION_METHOD}_{RECOMMENDATION_RATIO}'.lower()
     OUTPUT_PATH = COMPRESSED_MODEL_NAME + '.pt'
     compressed_model = compressor.recommendation_compression(
         model_id=model.model_id,
@@ -109,3 +309,29 @@ if __name__ == '__main__':
     )
 
     logger.info("Compression step end.")
+
+    """
+        Retrain YOLOv7 model
+    """
+    logger.info("Fine-tuning step start.")
+
+    opt.original = opt.weights
+    opt.compressed = OUTPUT_PATH
+    opt.detect = detect
+    pt_file = fx2p(opt)
+
+    torch.save(pt_file, COMPRESSED_MODEL_NAME + '_fx2p.pth')
+
+    with open(opt.hyp) as f:
+        hyp = yaml.safe_load(f)
+        hyp['lr0'] *= 0.1
+    
+    with open('tmp_hyp.yaml', 'w') as f:
+        yaml.safe_dump(hyp, f)
+    opt.hyp = 'tmp_hyp.yaml'
+
+    opt.weights = COMPRESSED_MODEL_NAME + '_fx2p.pth'
+    opt.netspresso = True
+    opt = train_run(opt)
+
+    logger.info("Fine-tuning step end.")


### PR DESCRIPTION
Slack link: https://nota-workspace.slack.com/archives/C040F65LSAJ/p1692766946904609
Notion link: https://www.notion.so/notaai/YOLOv7-64086efbdacf4feaa9a0575f04fa95a9?pvs=4

목적
---
ModelZoo에서 세분화된 기능을 하나로 합쳐서 하나의 파일만 실행하면 경량화 → 재학습 → onnx export까지 되어 LaunchX 사용 가능하게 한다.

변경 사항
---
- auto_process.py 파일을 생성했습니다. fx 변환, 경량화, 재학습, onnx 변환 이라는 단계를 거치며, 이를 위해 다음과 같은 argument를 받습니다.
  - 모델 이름 (ex. yolov7)
  - 모델 weight path (ex. yolov7.pt)
  - NetsPresso 계정 이메일
  - NetsPresso 계정 비밀번호
  - 그 외의 argument 들을 추가로 사용할 수 있으나, default 로도 사용 가능합니다.
- 최대한 기존 코드의 수정을 막기 위해, 필요한 코드들을 가져와 순서대로 작동하도록 구성했습니다.
  - train의 경우 train.py의 __main__에 존재하는 코드를 함수화한 뒤, train.py와 train_aux.py에 존재하는 train 함수를 호출하도록 구성되어 있습니다. 다른 함수를 호출하는 이유는 기존부터 모델마다 다른 train 함수를 사용하기 때문입니다. yolov7, yolov7x는 train.py를 사용하고, yolov7-w6, yolov7-e6, yolov7-d6, yolov7-e6e는 train_aug.py를 사용합니다.
  - onnx export 부분의 경우, export.py 에서 onnx 에 해당하는 부분을 가져와서 함수화 한 뒤 사용합니다.
- 재학습 전에 통과하는 yolov7_fx2p.py 코드를 수정했습니다.
  - NetsPresso 1.1.2 배포 이후 compressor의 모델 출력 형식이 달라졌는데, yolov7_fx2p.py의 함수는 아직 이를 반영하지 못한 상태였습니다.
  - 따라서 compressor를 통과한 모델을 잘 읽을 수 있도록 수정했으며, 동시에 auto_process.py에서 호출할 수 있도록 함수화를 진행했습니다.
- 코드 실행으로 발생하는 fx와 onnx 파일은 root 디렉토리에 생성됩니다.
- onnx export 이전에 통과하는 reparameterization 과정을 함수화해서 수정 및 추가했습니다. `def raparam(opt)`
  - reparameterization step이 ipynb 형식으로 제시되어 있었고, 각 모델마다 별도의 코드 블럭을 실행하도록 구성되어 있었기 때문에, 이를 함수화 해서 모델의 이름에 따라 적절한 reparameteriztion을 진행하도록 수정했습니다.
  - 더불어, reparameterization step의 코드에 논리적 오류가 존재하여 이를 수정했습니다.
- 테스트
  - 코드에 수정이 많았기 때문에 모든 모델에 대해서 테스트를 진행했습니다.
  - `python auto_process.py --name {model_name} --weights {model_path} --compression_method {compression} --recommendation_method {recommend} --np_email {email} --np_password {password}`
  - `model_name`: yolov7, yolov7x, yolov7-w6, yolov7-e6, yolov7-d6, yolov7-e6e
  - `compression`: PR_L2, FD_TK, FD_SVD
  - `recommend`: slamp, vbmf
