### PR TITLE
Remove augment, profile parameters in forward

### DIFF
--- a/auto_process.py
+++ b/auto_process.py
@@ -878,7 +878,7 @@ if __name__ == '__main__':
         model.load_state_dict(state_dict, strict=False)
 
     model.train()
-    _graph = fx.Tracer().trace(model, {'augment': False, 'profile':False})
+    _graph = fx.Tracer().trace(model)
     traced_model = fx.GraphModule(model, _graph)
     torch.save(traced_model, f"{opt.name}_fx.pt")
 

--- a/detect.py
+++ b/detect.py
@@ -80,12 +80,12 @@ def detect(save_img=False):
             old_img_h = img.shape[2]
             old_img_w = img.shape[3]
             for i in range(3):
-                model(img, augment=opt.augment)[0]
+                model(img)[0]#, augment=opt.augment)[0]
 
         # Inference
         t1 = time_synchronized()
         with torch.no_grad():   # Calculating gradients would cause a GPU memory leak
-            pred = model(img, augment=opt.augment)[0]
+            pred = model(img)[0]#, augment=opt.augment)[0]
         t2 = time_synchronized()
 
         # Apply NMS

--- a/export_netspresso.py
+++ b/export_netspresso.py
@@ -36,6 +36,6 @@ if __name__ == '__main__':
     import torch.fx as fx
 
     model.train()
-    _graph = fx.Tracer().trace(model, {'augment': False, 'profile':False})
+    _graph = fx.Tracer().trace(model)
     traced_model = fx.GraphModule(model, _graph)
     torch.save(traced_model, "yolov7_fx.pt")

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -582,7 +582,9 @@ class Model(nn.Module):
         self.info()
         logger.info('')
 
-    def forward(self, x, augment=False, profile=False):
+    def forward(self, x):
+        augment=False
+        profile=False
         if augment:
             img_size = x.shape[-2:]  # height, width
             s = [1, 0.83, 0.67]  # scales

--- a/test.py
+++ b/test.py
@@ -111,7 +111,7 @@ def test(data,
         with torch.no_grad():
             # Run model
             t = time_synchronized()
-            out, train_out = model(img, augment=augment)  # inference and training outputs
+            out, train_out = model(img)#, augment=augment)  # inference and training outputs
             t0 += time_synchronized() - t
 
             # Compute loss


### PR DESCRIPTION
Slack link 1: https://nota-workspace.slack.com/archives/C040F65LSAJ/p1699416473631079
Slack link 2: https://nota-workspace.slack.com/archives/C040F65LSAJ/p1700724737018359?thread_ts=1700539898.418389&cid=C040F65LSAJ

목적
---
fx 변환에서 concrete_args로 인해 에러가 발생하는 이유로 이를 제거한다.

변경 사항
---
- model forward의 augment, profile 파라미터를 내부에서 상수로 선언하는 것으로 변경

참조
---
